### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/alexojica/JetFormer/security/code-scanning/1](https://github.com/alexojica/JetFormer/security/code-scanning/1)

To resolve the issue, you should explicitly set the `permissions` key in the workflow YAML file. Since the provided workflow only appears to check out code, set up Python, install dependencies, and run some import checks (no deployment, no push, no label, no workflow dispatch, etc.), it only requires minimal read permissions to the repository contents. The most suitable fix is to set `permissions: contents: read` at the workflow root, which applies the least privilege to all jobs. This requires adding a block like:

```yaml
permissions:
  contents: read
```

right after the workflow `name` and before the `on:` block (it can go between lines 2 and 3). No changes to job or step logic are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set least-privilege `permissions: contents: read` at the root of the CI workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1473e3b3634549c3f53569784c04d5bbda5e089. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->